### PR TITLE
Update newznab.py to use the newznab nzb link

### DIFF
--- a/couchpotato/core/media/_base/providers/nzb/newznab.py
+++ b/couchpotato/core/media/_base/providers/nzb/newznab.py
@@ -71,9 +71,13 @@ class Base(NZBProvider, RSS):
             name = self.getTextElement(nzb, 'title')
             detail_url = self.getTextElement(nzb, 'guid')
             nzb_id = detail_url.split('/')[-1:].pop()
+            link = self.getTextElement(nzb, 'link')
 
             if '://' not in detail_url:
                 detail_url = (cleanHost(host['host']) + self.urls['detail']) % tryUrlencode(nzb_id)
+
+            if not link:
+                link = ((self.getUrl(host['host']) + self.urls['download']) % tryUrlencode(nzb_id)) + self.getApiExt(host)
 
             if not name:
                 continue
@@ -106,7 +110,7 @@ class Base(NZBProvider, RSS):
                 'name_extra': name_extra,
                 'age': self.calculateAge(int(time.mktime(parse(date).timetuple()))),
                 'size': int(self.getElement(nzb, 'enclosure').attrib['length']) / 1024 / 1024,
-                'url': ((self.getUrl(host['host']) + self.urls['download']) % tryUrlencode(nzb_id)) + self.getApiExt(host),
+                'url': link,
                 'detail_url': detail_url,
                 'content': self.getTextElement(nzb, 'description'),
                 'description': description,


### PR DESCRIPTION
If the newznab provider provides an nzb link xml tag this is used instead of constructing a link.
If no link tag is found in the newznab response the old logic is used.

This is mainly useful if the newznab provider passes links to nzbs that are not in the same domain as the api itself. (A content delivery network for example)
